### PR TITLE
Minor issue solved

### DIFF
--- a/jquery.colorpicker.js
+++ b/jquery.colorpicker.js
@@ -2068,7 +2068,7 @@
 				that.options.swatches = _colors;
 			}
 
-			if (this.element[0].nodeName.toLowerCase() === 'input') {
+			if (this.element[0].nodeName.toLowerCase() === 'input' || !this.inline) {
 				that._setColor(that.element.val());
 
 				this._callback('init');


### PR DESCRIPTION
Hi there, I found that only an <input> element seemed to allow a popup colorpicker.  This change allows me to manually specify "inline: false" in constuction and use any element to pop up the dialog.
