### PR TITLE
Fixed closing popup-colorpicker when dragging the scrollbar

### DIFF
--- a/jquery.colorpicker.js
+++ b/jquery.colorpicker.js
@@ -1885,7 +1885,7 @@
 				that.dialog = $('.ui-colorpicker:last');
 
 				// Click outside/inside
-				$(document).mousedown(function (event) {
+				$(document).delegate('html', 'touchstart click', function (event) {
 					if (!that.opened || event.target === that.element[0] || that.overlay) {
 						return;
 					}


### PR DESCRIPTION
When dragging the scrollbar, colorpickers, that are open as a popup, will close.

This is especially bad for small screens such as tablets or netbooks.

The commit delegates the click event to the html object instead of the document, so it will still trigger when clicking inside the html, but not when clicking on the scrollbar.
