### PR TITLE
Fix for latest jQuery version

### DIFF
--- a/jquery.colorpicker.js
+++ b/jquery.colorpicker.js
@@ -2380,10 +2380,10 @@
 				}
 				bottom	= $(window).height() + $(window).scrollTop();
 				right	= $(window).width() + $(window).scrollLeft();
-				height	= that.dialog.outerHeight();
+				height	= that.dialog.outerHeight(false);
 				width	= that.dialog.outerWidth();
 				x		= offset.left;
-				y		= offset.top + that.element.outerHeight();
+				y		= offset.top + that.element.outerHeight(false);
 
 				if (x + width > right) {
 					x = Math.max(0, right - width);


### PR DESCRIPTION
If you use the latest jQuery version for e.g. 1.9.1. The outerHeight() returns an object instead of a number, this cause the ui picker dialog to display at the bottom of the page.
