### PR TITLE
prefer localStorage over cookies

### DIFF
--- a/parts/jquery.ui.colorpicker-memory.js
+++ b/parts/jquery.ui.colorpicker-memory.js
@@ -29,16 +29,27 @@
 							container.append($node);
 						},
 			getMemory	= function() {
-							return (document.cookie.match(/\bcolorpicker-memory=([^;]*)/) || [0, ''])[1].split(',');
+							if (window.localStorage) {
+								var memory = localStorage.getItem('colorpicker-memory');
+								if (memory) {
+									return JSON.parse(memory);
+								}
+							}
+							return $.map((document.cookie.match(/\bcolorpicker-memory=([^;]*)/) || [0, ''])[1].split(','),unescape);
 						};
 			setMemory	= function() {
 							var colors = [];
 							$('> *', container).each(function() {
-								colors.push(escape($(this).css('backgroundColor')));
+								colors.push($(this).css('backgroundColor'));
 							});
-							var expdate=new Date();
-							expdate.setDate(expdate.getDate() + (365 * 10));
-							document.cookie = 'colorpicker-memory='+colors.join()+";expires="+expdate.toUTCString();
+							if (window.localStorage) {
+								localStorage.setItem('colorpicker-memory',JSON.stringify(colors));
+							}
+							else {
+								var expdate=new Date();
+								expdate.setDate(expdate.getDate() + (365 * 10));
+								document.cookie = 'colorpicker-memory='+$.map(colors,escape).join()+';expires='+expdate.toUTCString();
+							}
 						};
 
 		this.init = function () {
@@ -52,7 +63,7 @@
 							.appendTo($('.ui-colorpicker-memory-container', inst.dialog));
 
 			$.each(getMemory(), function() {
-				addNode(unescape(this));
+				addNode(this);
 			});
 
 			container.mousedown(function(e) {


### PR DESCRIPTION
There is no need to send remembered colors to server and even IE8 supports localStorage & JSON.

I implemented it so that it falls back to cookies if there is no support for localStorage or if no colores are found in the localStorage (-> it upgrades from cookies if the old version was already used).
