### PR TITLE
remove spaces from name, add description

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
-  "name": "Vanderlee Colorpicker",
+  "name": "colorpicker",
+  "description": "Vanderlee Colorpicker",
   "version": "1.1.2",
   "homepage": "https://github.com/vanderlee/colorpicker",
   "authors": [


### PR DESCRIPTION
Fix for:
https://github.com/vanderlee/colorpicker/issues/101

Makes the name property in bower.json "slug" style, so that it can be used nicely in urls, as recommended in the [bower.json spec](http://bower.io/docs/creating-packages/#name).

I'm not sure what implications this will have for people that have already installed with the old name, so option B is to just use quotes in the CSS url paths, but really I think fixing the name is the way to go--spaces in file paths can cause other kinds of problems, as well.