### PR TITLE
Fixed resize event unbinding on window inside destroy

### DIFF
--- a/jquery.colorpicker.js
+++ b/jquery.colorpicker.js
@@ -2895,8 +2895,8 @@
 				$(document).off('keydown', that.events.document_keydown);
 			}
 			
-			if (that.events.resizeOverlay !== null) {
-				$(window).off('resize', that.events.resizeOverlay);					
+			if (that.events.window_resize !== null) {
+				$(window).off('resize', that.events.window_resize);					
 			}			
 			
 			this.element.off();


### PR DESCRIPTION
The destroy function of the widget removes all resize event handlers, bound on the window through jQuery, not just the handler of the widget. This pull request fixes that by replacing the undefined `that.events.resizeOverlay` with `that.events.window_resize` inside `destroy`. As a result the correct handler function is passed to jQuery's `off` function, instead of undefined.

The following code is a minimal example to reproduce the problem. After clicking the destroy button the window size is no longer updated.
```html
<!DOCTYPE html>
<html>
    <head>
        <title>Destroy resize unbinding example</title>
        <link href="jquery-ui.css" rel="stylesheet" type="text/css">
        <link href="jquery.colorpicker.css" rel="stylesheet" type="text/css">
        <script src="jquery.js"></script>
        <script src="jquery-ui.js"></script>
        <script src="jquery.colorpicker.js"></script>
    </head>
    <body>
        <input type="text" id="colorpicker-popup" value="fe9810">
        <button id="destroy">Destroy</button>
        Window size: <span id="size"></span>
        <script type="text/javascript">
            $(function() {
                $('#colorpicker-popup').colorpicker(); // We bind a resize event on the window
                $(window).on('resize', updateSize); // Another resize event is bound using jQuery
                $('#destroy').on('click', function() {
                    $('#colorpicker-popup').colorpicker('destroy'); // Will unbind all resize events on window, not only its own
                    var size$ = $('#size');
                    size$.text(size$.text() + ' (no longer updated)');
                });
                updateSize();
            });
            function updateSize() {
                var win$ = $(window);
                $('#size').text(win$.width() + ' x ' + win$.height());
            }
        </script>
    </body>
</html>
```