### PR TITLE
Increase required version for jquery, jqueryUI to align with README

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "tests"
   ],
   "dependencies": {
-	"jquery": ">=1.5",
-    "jquery-ui": ">=1.7"
+    "jquery": ">=1.7.1",
+    "jquery-ui": ">=1.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanderlee-colorpicker",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "homepage": "https://github.com/vanderlee/colorpicker",
   "author": "Martijn van der Lee <martijn@vanderlee.com>",
   "repository": {
@@ -22,7 +22,7 @@
     "tests"
   ],
   "dependencies": {
-    "jquery": ">=1.5",
-    "jquery-ui": ">=1.7"
+    "jquery": ">=1.7.1",
+    "jquery-ui": ">=1.8.0"
   }
 }


### PR DESCRIPTION
Also bump the version in package.json

This means that a `npm publish` action is required, as the version on npm is still 1.2.16, whereas the 1.2.17 tag exists on the repo. Note that the bower.json had a correct version string.