### PR TITLE
Harden npm package metadata and contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,25 +1,38 @@
 {
   "name": "vanderlee-colorpicker",
   "version": "1.2.20",
+  "description": "jQuery UI color picker with RGB, HSL, HSV, CMYK, L*a*b, alpha, swatches, localization, and theming support.",
   "homepage": "https://github.com/vanderlee/colorpicker",
   "author": "Martijn van der Lee <martijn@vanderlee.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/vanderlee/colorpicker"
+    "url": "git+https://github.com/vanderlee/colorpicker.git"
   },
-  "description": "JQuery colorpicker: themeroller styling, RGB, HSL, CMYK and L*A*B support. Standard look & feel, configurable. Works as a popup or inline.",
+  "bugs": {
+    "url": "https://github.com/vanderlee/colorpicker/issues"
+  },
   "main": "jquery.colorpicker.js",
+  "style": "jquery.colorpicker.css",
+  "files": [
+    "jquery.colorpicker.js",
+    "jquery.colorpicker.css",
+    "i18n/",
+    "images/",
+    "parsers/",
+    "parts/",
+    "swatches/",
+    "CHANGELOG.md",
+    "LICENSE",
+    "README.md"
+  ],
   "keywords": [
     "jquery",
-    "colorpicker"
+    "jquery-ui",
+    "color",
+    "colorpicker",
+    "picker"
   ],
   "license": "MIT",
-  "ignore": [
-    "**/.*",
-    "node_modules",
-    "bower_components",
-    "test"
-  ],
   "scripts": {
     "test": "node scripts/validate-package.js",
     "pack:check": "npm pack --dry-run"


### PR DESCRIPTION
## What changed
- Add canonical repository and issue-tracker metadata.
- Expose the distributed stylesheet through the conventional `style` field.
- Replace the Bower-oriented `ignore` field with an explicit npm `files` allowlist.
- Limit published artifacts to the runtime plugin, stylesheet, assets, extensions, license, changelog, and README.
- Improve the package description and discovery keywords.

## Why
The package currently has no npm publication allowlist, so repository-only files such as demos, tests, configuration, and development scripts can be included in releases. An explicit file list makes the published package smaller and its contents reviewable through the package dry-run added by the validation PR.

## Dependency
This is a stacked draft based on PR #186, which adds `npm pack --dry-run` validation. After PR #186 merges, this PR can be retargeted to `master`.

## Validation
Not run locally because this environment cannot install npm dependencies. The stacked workflow validates JSON, source syntax, and the resulting npm package manifest.