### PR TITLE
Support dragging the color map and bar with touch

### DIFF
--- a/jquery.colorpicker.js
+++ b/jquery.colorpicker.js
@@ -616,23 +616,31 @@
         var that = this,
           part = null,
           pointer, width, height, layers = {},
-          _mousedown, _mouseup, _mousemove, _keydown, _html;
+          _mousedown, _mouseup, _mousemove, _keydown, _html,
+          _coordinates = function (event) {
+            var original = event.originalEvent || event,
+              touch = (original.touches && original.touches[0]) ||
+                (original.changedTouches && original.changedTouches[0]);
+
+            return touch || event;
+          };
 
         _mousedown = function (event) {
           if (!inst.opened) {
             return;
           }
 
-          var offset = layers.p.offset(),
-            x = event.pageX - offset.left,
-            y = event.pageY - offset.top;
+          var coordinates = _coordinates(event),
+            offset = layers.p.offset(),
+            x = coordinates.pageX - offset.left,
+            y = coordinates.pageY - offset.top;
 
           if (x >= 0 && x < width && y >= 0 && y < height) {
             event.stopImmediatePropagation();
             event.preventDefault();
-            part.off('mousedown', _mousedown).focus();
-            $(document).on('mouseup', _mouseup);
-            $(document).on('mousemove', _mousemove);
+            part.off('mousedown touchstart', _mousedown).focus();
+            $(document).on('mouseup touchend touchcancel', _mouseup);
+            $(document).on('mousemove touchmove', _mousemove);
             _mousemove(event);
           }
         };
@@ -640,9 +648,9 @@
         _mouseup = function (event) {
           event.stopImmediatePropagation();
           event.preventDefault();
-          $(document).off('mouseup', _mouseup);
-          $(document).off('mousemove', _mousemove);
-          part.on('mousedown', _mousedown);
+          $(document).off('mouseup touchend touchcancel', _mouseup);
+          $(document).off('mousemove touchmove', _mousemove);
+          part.on('mousedown touchstart', _mousedown);
 
           inst._callback('stop');
         };
@@ -651,15 +659,17 @@
           event.stopImmediatePropagation();
           event.preventDefault();
 
-          if (event.pageX === that.x && event.pageY === that.y) {
+          var coordinates = _coordinates(event);
+
+          if (coordinates.pageX === that.x && coordinates.pageY === that.y) {
             return;
           }
-          that.x = event.pageX;
-          that.y = event.pageY;
+          that.x = coordinates.pageX;
+          that.y = coordinates.pageY;
 
           var offset = layers.p.offset(),
-            x = event.pageX - offset.left,
-            y = event.pageY - offset.top;
+            x = coordinates.pageX - offset.left,
+            y = coordinates.pageY - offset.top;
 
           x = Math.max(0, Math.min(x / width, 1));
           y = Math.max(0, Math.min(y / height, 1));
@@ -767,7 +777,7 @@
         this.init = function () {
           part = $(_html()).appendTo($('.ui-colorpicker-map-container', inst.dialog));
 
-          part.on('mousedown', _mousedown);
+          part.on('mousedown touchstart', _mousedown);
           part.on('keydown', _keydown);
 
           // cache
@@ -881,7 +891,7 @@
         };
 
         this.disable = function (disable) {
-          part[disable ? 'off' : 'on']('mousedown', _mousedown);
+          part[disable ? 'off' : 'on']('mousedown touchstart', _mousedown);
           part[disable ? 'off' : 'on']('keydown', _keydown);
         };
       },
@@ -890,23 +900,31 @@
         var that = this,
           part = null,
           pointer, width, height, layers = {},
-          _mousedown, _mouseup, _mousemove, _keydown, _html;
+          _mousedown, _mouseup, _mousemove, _keydown, _html,
+          _coordinates = function (event) {
+            var original = event.originalEvent || event,
+              touch = (original.touches && original.touches[0]) ||
+                (original.changedTouches && original.changedTouches[0]);
+
+            return touch || event;
+          };
 
         _mousedown = function (event) {
           if (!inst.opened) {
             return;
           }
 
-          var offset = layers.p.offset(),
-            x = event.pageX - offset.left,
-            y = event.pageY - offset.top;
+          var coordinates = _coordinates(event),
+            offset = layers.p.offset(),
+            x = coordinates.pageX - offset.left,
+            y = coordinates.pageY - offset.top;
 
           if (x >= 0 && x < width && y >= 0 && y < height) {
             event.stopImmediatePropagation();
             event.preventDefault();
-            part.off('mousedown', _mousedown).focus();
-            $(document).on('mouseup', _mouseup);
-            $(document).on('mousemove', _mousemove);
+            part.off('mousedown touchstart', _mousedown).focus();
+            $(document).on('mouseup touchend touchcancel', _mouseup);
+            $(document).on('mousemove touchmove', _mousemove);
             _mousemove(event);
           }
         };
@@ -914,9 +932,9 @@
         _mouseup = function (event) {
           event.stopImmediatePropagation();
           event.preventDefault();
-          $(document).off('mouseup', _mouseup);
-          $(document).off('mousemove', _mousemove);
-          part.on('mousedown', _mousedown);
+          $(document).off('mouseup touchend touchcancel', _mouseup);
+          $(document).off('mousemove touchmove', _mousemove);
+          part.on('mousedown touchstart', _mousedown);
 
           inst._callback('stop');
         };
@@ -925,13 +943,15 @@
           event.stopImmediatePropagation();
           event.preventDefault();
 
-          if (event.pageY === that.y) {
+          var coordinates = _coordinates(event);
+
+          if (coordinates.pageY === that.y) {
             return;
           }
-          that.y = event.pageY;
+          that.y = coordinates.pageY;
 
           var offset  = layers.p.offset(),
-            y = event.pageY - offset.top;
+            y = coordinates.pageY - offset.top;
 
           y = Math.max(0, Math.min(y / height, 1));
 
@@ -1018,7 +1038,7 @@
         this.init = function () {
           part = $(_html()).appendTo($('.ui-colorpicker-bar-container', inst.dialog));
 
-          part.on('mousedown', _mousedown);
+          part.on('mousedown touchstart', _mousedown);
           part.on('keydown', _keydown);
 
           // cache
@@ -1167,7 +1187,7 @@
         };
 
         this.disable = function (disable) {
-          part[disable ? 'off' : 'on']('mousedown', _mousedown);
+          part[disable ? 'off' : 'on']('mousedown touchstart', _mousedown);
           part[disable ? 'off' : 'on']('keydown', _keydown);
         };
       },


### PR DESCRIPTION
## What changed
- Listen for touch start, move, end, and cancel events on the color map and value bar.
- Normalize mouse and touch coordinates before applying color changes.
- Preserve the existing mouse and keyboard behavior.

## Why
The controls handled a touch tap only as a synthesized mouse event. Continuing to move a finger did not update the selection because dragging listened exclusively for mouse movement.

This makes touch dragging behave like mouse dragging and fixes #127.

## Validation
- Exercised touchstart/touchmove/touchend against both the plugin and a real DOM implementation in an isolated jsdom integration harness.
- Confirmed that movement changes the selected color and emits selection callbacks.
- Ran `node --check jquery.colorpicker.js`.