### PR TITLE
Add readable alt field text contrast

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Whether or not to show the inputs for alpha.
 ### altAlpha (true)
 Change the opacity of the altField element(s) according to the alpha setting.
 
+### altContrast (false)
+Set the altField text color to black or white, whichever has the greater WCAG
+contrast against the selected color.
+
 ### altField ('')
 Change the background color of the elements specified in this element.
 

--- a/jquery.colorpicker.js
+++ b/jquery.colorpicker.js
@@ -48,6 +48,20 @@
       return touch || event;
     },
 
+    _contrastTextColor = function(color) {
+      var rgb = color.getRGB(),
+        linear = function(channel) {
+          return channel <= 0.04045
+            ? channel / 12.92
+            : Math.pow((channel + 0.055) / 1.055, 2.4);
+        },
+        luminance = 0.2126 * linear(rgb.r)
+          + 0.7152 * linear(rgb.g)
+          + 0.0722 * linear(rgb.b);
+
+      return luminance > 0.179 ? '#000000' : '#ffffff';
+    },
+
     _keycode = {
       isPrint: function(keycode) {
         return keycode == 32 // spacebar
@@ -2334,6 +2348,7 @@
     options: {
       alpha:        false,    // Show alpha controls and mode
       altAlpha:     true,   // change opacity of altField as well?
+      altContrast:    false,    // use black or white text for contrast with the selected color.
       altField:     '',     // selector for DOM elements which change background color on change.
       altOnChange:    true,   // true to update on each change, false to update only on close.
       altProperties:    'background-color', // comma separated list of any of 'background-color', 'color', 'border-color', 'outline-color'
@@ -2570,7 +2585,8 @@
      */
     _setAltField: function () {
       if (this.options.altOnChange && this.options.altField && this.options.altProperties) {
-        var index,
+        var $altField = $(this.options.altField),
+          index,
           property,
           properties = this.options.altProperties.split(',');
 
@@ -2584,13 +2600,17 @@
           case 'backgroundColor':
           case 'outline-color':
           case 'border-color':
-            $(this.options.altField).css(property, this.color.set? this.color.toCSS() : '');
+            $altField.css(property, this.color.set? this.color.toCSS() : '');
             break;
           }
         }
 
+        if (this.options.altContrast) {
+          $altField.css('color', this.color.set ? _contrastTextColor(this.color) : '');
+        }
+
         this.options.altAlpha &&
-          $(this.options.altField).css('opacity', this.color.set? this.color.getAlpha() : '');
+          $altField.css('opacity', this.color.set? this.color.getAlpha() : '');
       }
     },
 

--- a/test/events.js
+++ b/test/events.js
@@ -23,6 +23,29 @@ test('Empty input value should not set altField background to black', function()
   equal($altfield.css('backgroundColor'), 'rgba(0, 0, 0, 0)', 'After close, no color');
 });
 
+test('altContrast should keep altField text readable', function() {
+  expect(4);
+
+  var $input = $('<input type="text" value="#000000"/>').appendTo('#qunit-fixture');
+  var $altfield = $('<div></div>').appendTo('#qunit-fixture');
+
+  var jqcp = $input.colorpicker({
+    altContrast: true,
+    altField: $altfield
+  });
+
+  equal($altfield.css('color'), 'rgb(255, 255, 255)', 'Dark colors use white text');
+
+  jqcp.colorpicker('setColor', '#ffffff');
+  equal($altfield.css('color'), 'rgb(0, 0, 0)', 'Light colors use black text');
+
+  jqcp.colorpicker('setColor', '#777777');
+  equal($altfield.css('color'), 'rgb(0, 0, 0)', 'The text color with the greater contrast is used');
+
+  jqcp.colorpicker('setColor', '');
+  equal($altfield[0].style.color, '', 'No color restores the stylesheet text color');
+});
+
 asyncTest('Changing the color in input should trigger a \'change\' event on the input', function() {
   expect(1);
 


### PR DESCRIPTION
## What changed
- Add an opt-in `altContrast` setting for alternate fields.
- Choose black or white text using WCAG relative luminance so the selected background color remains readable.
- Restore stylesheet-controlled text color when no color is selected.
- Document the option and add coverage for dark, light, boundary, unset, and opt-in behavior.

## Why
Issue #121 requested readable text when an `altField` uses the selected color as its background. The attached proposal hardcoded an application-specific CSS class and an older brightness heuristic; this provides the behavior generically without changing existing styling by default.

## Validation
- `node --check jquery.colorpicker.js`
- `node scripts/validate-package.js`
- Existing legacy plugin integration harness
- Focused jsdom checks for alt-field contrast behavior
- `git diff --check`

Fixes #121