### PR TITLE
Add npm publishing workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,66 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing semantic version tag to publish
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: npm-publish-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          package-manager-cache: false
+          registry-url: https://registry.npmjs.org
+
+      - name: Verify release tag matches package version
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        run: |
+          package_version="$(node -p "require('./package.json').version")"
+
+          if [ "$RELEASE_TAG" != "$package_version" ]; then
+            echo "::error::Tag $RELEASE_TAG does not match package version $package_version"
+            exit 1
+          fi
+
+          if ! git tag --points-at HEAD | grep -Fxq "$RELEASE_TAG"; then
+            echo "::error::$RELEASE_TAG does not point at the checked-out commit"
+            exit 1
+          fi
+
+      - name: Validate package
+        run: |
+          npm test
+          npm run pack:check
+
+      - name: Publish package
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What changed
- Publish `vanderlee-colorpicker` when a plain semantic-version tag such as `1.2.21` is pushed.
- Support guarded manual publishing of an existing version tag, which can be used to catch npm up from `1.2.16` to the repository's later tags.
- Reject publishes when the selected tag does not match `package.json` or does not point at the checked-out commit.
- Validate the package and dry-run its contents before publishing.
- Enable npm provenance and OIDC trusted publishing, with `NPM_TOKEN` supported as a fallback.
- Serialize publishes to prevent concurrent release races.

## Authentication setup
Preferred: configure an npm trusted publisher for:
- GitHub owner: `vanderlee`
- Repository: `colorpicker`
- Workflow filename: `publish-npm.yml`
- Allowed action: `npm publish`
- Environment: leave blank

Alternatively, add an Actions repository secret named `NPM_TOKEN` containing an npm automation token.

## Validation
- Repository package validation passed.
- Workflow YAML parses and matches pinned Prettier 3.6.2 formatting.
- Existing tag `1.2.20` was verified to match its `package.json` version and checked-out commit.
- Workflow content was read back from the remote branch after creation.