### PR TITLE
Prepare 1.2.21 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.2.21 - 2026-08-03
+### Added
+- Added touch dragging for the color map and value bar (#127, #190).
+- Added the opt-in `altContrast` option for readable altField text (#121, #196).
+- Added dependency-free package validation, GitHub Actions CI, and automated npm publishing.
+
+### Changed
+- Hardened npm package metadata and limited published files to runtime assets and documentation.
+- Updated development dependencies with accumulated security fixes.
+
+### Fixed
+- Restored compatibility with jQuery UI 1.14 when optional footer buttons are disabled (#182, #188).
+
 ## 1.2.20 - 2019-09-01
 ### Fixed
 - Merged security patches for third party components.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Release](https://badge.fury.io/js/vanderlee-colorpicker.svg)](https://badge.fury.io/js/vanderlee-colorpicker)
 [![License](https://img.shields.io/github/license/vanderlee/colorpicker.svg)](https://choosealicense.com/licenses/mit/)
 
-Copyright © 2011-2019 Martijn W. van der Lee.
+Copyright © 2011-2026 Martijn W. van der Lee.
 
 Most images from jPicker by Christopher T. Tillman.
 Sourcecode created from scratch by Martijn W. van der Lee.
@@ -55,6 +55,16 @@ With **yarn**: `yarn add vanderlee-colorpicker`
 With **bower** (deprecated): `bower install colorpicker`
 
 Zip archive: https://github.com/vanderlee/colorpicker/archive/master.zip
+
+What's new in 1.2.21
+--------------------
+
+- Touch dragging for the color map and value bar.
+- Compatibility with jQuery UI 1.14 when optional footer controls are disabled.
+- The opt-in `altContrast` option for readable text on colorized alt fields.
+- Hardened npm package contents, automated validation, and release publishing.
+
+See the [CHANGELOG](CHANGELOG.md) for the complete release history.
 
 jQueryUI custom build
 ---------------------

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "colorpicker",
-  "version": "1.2.20",
+  "version": "1.2.21",
   "homepage": "https://github.com/vanderlee/colorpicker",
   "authors": [
     "Martijn van der Lee <martijn@vanderlee.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanderlee-colorpicker",
-  "version": "1.2.20",
+  "version": "1.2.21",
   "description": "jQuery UI color picker with RGB, HSL, HSV, CMYK, L*a*b, alpha, swatches, localization, and theming support.",
   "homepage": "https://github.com/vanderlee/colorpicker",
   "author": "Martijn van der Lee <martijn@vanderlee.com>",


### PR DESCRIPTION
## What changed
- Bump npm and Bower package versions to `1.2.21`.
- Add complete 1.2.21 release notes to the changelog.
- Add a concise 1.2.21 summary to the README and update the copyright year.

## Release highlights
- Touch dragging for the map and value bar.
- jQuery UI 1.14 compatibility for optional footer controls.
- Opt-in readable alt-field text through `altContrast`.
- Hardened npm package contents, validation CI, and automated publishing.
- Accumulated development-dependency security updates.

## Validation
- Repository JSON and JavaScript validation passed.
- `git diff --check` passed.
- `npm@11.5.1 pack --dry-run --json` produced `vanderlee-colorpicker@1.2.21` with 47 intended files.

After this PR merges, tag `1.2.21`, create the GitHub Release from these notes, and verify the npm publishing workflow.